### PR TITLE
Arreglo crash al intentar getPackageName() demasiado pronto

### DIFF
--- a/RateMe/src/androidsx/rateme/HelloWorldActivity.java
+++ b/RateMe/src/androidsx/rateme/HelloWorldActivity.java
@@ -17,7 +17,6 @@ public class HelloWorldActivity extends Activity {
     
     private Button btnRateme;
     private libraryRateMe dialogo;
-    private String appName = getPackageName();
     
 
     @Override
@@ -72,8 +71,7 @@ public class HelloWorldActivity extends Activity {
 //        dialogo.show(fragmentManager, "Rate Us");
         
         
-        DialogFragment dialogo = libraryRateMe.newInstance(
-                appName);
+        DialogFragment dialogo = libraryRateMe.newInstance(getPackageName());
         dialogo.show(getFragmentManager(), "dialog");
     }
     


### PR DESCRIPTION
El getPackageName() se estaba ejecutando antes de que Android cargara la activity por completo. Este tipo de llamadas solo se pueden hacer tras el onCreate(). Por eso nos llevabamos un crash aqui.

@pocho23 revies & merge!
