### PR TITLE
Display the button if stars are pre-selected

### DIFF
--- a/LibraryRateMe/src/com/androidsx/rateme/DialogRateMe.java
+++ b/LibraryRateMe/src/com/androidsx/rateme/DialogRateMe.java
@@ -112,7 +112,13 @@ public class DialogRateMe extends DialogFragment {
                 }
             }
         });
-        ratingBar.setRating((float) defaultStarsSelected);
+
+        // If any star is pre-selected, force the display of the buttons
+        if (defaultStarsSelected != 0) {
+            ratingBar.setRating((float) defaultStarsSelected);
+            rateMe.setVisibility(View.VISIBLE);
+            noThanks.setVisibility(View.GONE);
+        }
         configureButtons();
         close.setOnClickListener(new OnClickListener() {
             @Override


### PR DESCRIPTION
Revisa este bugfix, @pocho23.

Sin esto, el dialog aparece asi en el caso de que se haya usado el `setDefaultStarsSelected`:

![device-2014-09-08-130909](https://cloud.githubusercontent.com/assets/121440/4189300/e24d2158-377a-11e4-9363-07fe98f88ae5.png)
