### PR TITLE
Added Creator object to DefaultOnRatingListener

### DIFF
--- a/LibraryRateMe/src/com/androidsx/rateme/OnRatingListener.java
+++ b/LibraryRateMe/src/com/androidsx/rateme/OnRatingListener.java
@@ -71,7 +71,8 @@ class DefaultOnRatingListener implements OnRatingListener {
     
     public static final Parcelable.Creator CREATOR = new Parcelable.Creator() {
         public DefaultOnRatingListener createFromParcel(Parcel in) {
-            return new DefaultOnRatingListener(in);
+            //return new DefaultOnRatingListener(in);
+            return new DefaultOnRatingListener();
         } 
      
         public DefaultOnRatingListener[] newArray(int size) {

--- a/LibraryRateMe/src/com/androidsx/rateme/OnRatingListener.java
+++ b/LibraryRateMe/src/com/androidsx/rateme/OnRatingListener.java
@@ -68,4 +68,14 @@ class DefaultOnRatingListener implements OnRatingListener {
     public void writeToParcel(Parcel dest, int flags) {
         // Nothing to write
     }
+    
+    public static final Parcelable.Creator CREATOR = new Parcelable.Creator() {
+        public DefaultOnRatingListener createFromParcel(Parcel in) {
+            return new DefaultOnRatingListener(in);
+        } 
+     
+        public DefaultOnRatingListener[] newArray(int size) {
+            return new DefaultOnRatingListener[size];
+        } 
+    };     
 }


### PR DESCRIPTION
Added Creator object to DefaultOnRatingListener as it is set extends Parcelable
Otherwise, it will throw a RuntimeException: Parcelable protocol requires a Parcelable.Creator object called CREATOR